### PR TITLE
User mapping

### DIFF
--- a/plugins/module_utils/arguments.py
+++ b/plugins/module_utils/arguments.py
@@ -91,6 +91,7 @@ SHARED_SPECS = dict(
             ),
         ),
     ),
+    mapping=dict(type="dict", required=False),
 )
 
 

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -43,10 +43,17 @@ class PayloadMapper:
         self.unknown_value_handler = unknown_value_handler
 
         for key, value_map in mapping.items():
-            self._to_ansible[key] = dict(value_map)
-            self._to_snow[key] = dict(
-                (ansible_val, snow_val) for snow_val, ansible_val in value_map
-            )
+            if isinstance(value_map, dict):
+                self._to_ansible[key] = value_map
+                self._to_snow[key] = dict(
+                    (ansible_val, snow_val) for snow_val, ansible_val in value_map.items()
+                )
+            else:
+                self._to_ansible[key] = dict(value_map)
+                self._to_snow[key] = dict(
+                    (ansible_val, snow_val) for snow_val, ansible_val in value_map
+                )
+
 
     def _map_key(self, key, val, mapping):
         if val in mapping[key]:

--- a/plugins/modules/incident.py
+++ b/plugins/modules/incident.py
@@ -214,7 +214,12 @@ def validate_params(params, incident=None):
 
 
 def ensure_present(module, table_client, attachment_client):
-    mapper = utils.PayloadMapper(PAYLOAD_FIELDS_MAPPING, module.warn)
+    if "mapping" in module.params and "incident" in module.params["mapping"]:
+        choices = module.params["mapping"]["incident"]
+    else:
+        choices = PAYLOAD_FIELDS_MAPPING
+    mapper = utils.PayloadMapper(choices, module.warn)
+
     query = utils.filter_dict(module.params, "sys_id", "number")
     payload = build_payload(module, table_client)
     attachments = attachment.transform_metadata_list(
@@ -343,6 +348,10 @@ def main():
         ),
         other=dict(
             type="dict",
+        ),
+        mapping=dict(
+            type="dict",
+            required=False
         ),
     )
 

--- a/tests/integration/targets/incident/tasks/main.yml
+++ b/tests/integration/targets/incident/tasks/main.yml
@@ -3,18 +3,45 @@
     SN_USERNAME: "{{ sn_username }}"
     SN_PASSWORD: "{{ sn_password }}"
 
+  vars:
+    mapping:
+      incident:
+        impact:
+          1: "high"
+          2: "medium"
+          3: "low"
+        urgency:
+          1: "high"
+          2: "medium"
+          3: "low"
+        state:
+          1: "new"
+          2: "in_progress"
+          3: "on_hold"
+          6: "resolved"
+          7: "closed"
+          8: "canceled"
+        hold_reason:
+          "": ""
+          1: "awaiting_caller"
+          3: "awaiting_problem"
+          4: "awaiting_vendor"
+          5: "awaiting_change"
+
+
   block:
-    - name: Retrieve all incidents
-      servicenow.itsm.incident_info:
-      register: result
+    #- name: Retrieve all incidents
+    #  servicenow.itsm.incident_info:
+    #    mapping: "{{ mapping }}"
+    #  register: result
 
-    - ansible.builtin.assert:
-        that:
-          - result.records != []
-
+    #- ansible.builtin.assert:
+    #    that:
+    #      - result.records != []
 
     - name: Create test incident - check mode
       servicenow.itsm.incident: &create-incident
+        mapping: "{{ mapping }}"
         caller: admin
         state: new
         short_description: Test incident
@@ -48,6 +75,7 @@
 
     - name: Make sure incident exists
       servicenow.itsm.incident_info:
+        mapping: "{{ mapping }}"
         number: "{{ test_result.record.number }}"
       register: result
 
@@ -61,6 +89,7 @@
 
     - name: Update incident with same urgency and impact - unchanged
       servicenow.itsm.incident:
+        mapping: "{{ mapping }}"
         caller: admin
         number: "{{ test_result.record.number }}"
         impact: low
@@ -74,6 +103,7 @@
 
     - name: Update incident - check mode
       servicenow.itsm.incident: &update-incident
+        mapping: "{{ mapping }}"
         caller: admin
         number: "{{ test_result.record.number }}"
         state: in_progress
@@ -98,6 +128,7 @@
 
     - name: Make sure incident was updated
       servicenow.itsm.incident_info:
+        mapping: "{{ mapping }}"
         number: "{{ test_result.record.number }}"
       register: result
 
@@ -120,6 +151,7 @@
 
     - name: Fail closing incident without required data
       servicenow.itsm.incident:
+        mapping: "{{ mapping }}"
         number: "{{ test_result.record.number }}"
         state: closed
       ignore_errors: true
@@ -133,6 +165,7 @@
 
     - name: Update incident state - check mode
       servicenow.itsm.incident: &update-incident-state
+        mapping: "{{ mapping }}"
         caller: admin
         number: "{{ test_result.record.number }}"
         state: resolved
@@ -157,6 +190,7 @@
 
     - name: Get specific incident info by sysparm query
       servicenow.itsm.incident_info:
+        mapping: "{{ mapping }}"
         query:
          - caller: = admin
            number: = {{ test_result.record.number }}
@@ -177,6 +211,7 @@
 
     - name: Make sure incident state was updated
       servicenow.itsm.incident_info:
+        mapping: "{{ mapping }}"
         number: "{{ test_result.record.number }}"
       register: result
 
@@ -190,6 +225,7 @@
 
     - name: Get incident info by sysparm query - close_notes and state
       servicenow.itsm.incident_info:
+        mapping: "{{ mapping }}"
         query:
          - close_notes: LIKE Done testing
            state: = resolved
@@ -212,6 +248,7 @@
 
     - name: Delete incident - check mode
       servicenow.itsm.incident: &delete-incident
+        mapping: "{{ mapping }}"
         caller: admin
         number: "{{ test_result.record.number }}"
         state: absent
@@ -231,6 +268,7 @@
 
     - name: Make sure incident is absent
       servicenow.itsm.incident_info:
+        mapping: "{{ mapping }}"
         number: "{{ test_result.record.number }}"
       register: result
 
@@ -241,6 +279,7 @@
 
     - name: Test bad parameter combinator (number + query)
       servicenow.itsm.incident_info:
+        mapping: "{{ mapping }}"
         number: "{{ test_result.record.number }}"
         query:
          - short_description: LIKE SAP
@@ -255,6 +294,7 @@
 
     - name: Test invalid operator detection
       servicenow.itsm.incident_info:
+        mapping: "{{ mapping }}"
         query:
          - short_description: LIKEE SAP
       ignore_errors: true
@@ -268,6 +308,7 @@
 
     - name: Get incident info by sysparm query - short_description
       servicenow.itsm.incident_info:
+        mapping: "{{ mapping }}"
         query:
          - short_description: LIKE SAP
       register: result
@@ -279,6 +320,7 @@
 
     - name: Test unary operator with argument detection
       servicenow.itsm.incident_info:
+        mapping: "{{ mapping }}"
         query:
          - short_description: ISEMPTY SAP
       ignore_errors: true
@@ -292,6 +334,7 @@
 
     - name: Test sysparm query unary operator - short_description
       servicenow.itsm.incident_info:
+        mapping: "{{ mapping }}"
         query:
          - short_description: ISNOTEMPTY
       register: result

--- a/tests/integration/targets/incident/tasks/main.yml
+++ b/tests/integration/targets/incident/tasks/main.yml
@@ -30,14 +30,14 @@
 
 
   block:
-    #- name: Retrieve all incidents
-    #  servicenow.itsm.incident_info:
-    #    mapping: "{{ mapping }}"
-    #  register: result
+    - name: Retrieve all incidents
+      servicenow.itsm.incident_info:
+        mapping: "{{ mapping }}"
+      register: result
 
-    #- ansible.builtin.assert:
-    #    that:
-    #      - result.records != []
+    - ansible.builtin.assert:
+        that:
+          - result.records != []
 
     - name: Create test incident - check mode
       servicenow.itsm.incident: &create-incident


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #085".

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Incident

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
User can change almost any enum inside `Choice lists` (https://docs.servicenow.com/bundle/rome-platform-administration/page/administer/field-administration/concept/c_ChoiceLists.html)

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Table that holds values can be edited on this endpoint. From tests it supports all CRUD opertions.
https://dev????.service-now.com/nav_to.do?uri=%2Fsys_choice_list.do%3Fsysparm_userpref_module%3Ddf35443dc0a8016600170b6df0ac4f5d%26sysparm_clear_stack%3Dtrue

Meaning that module needs to support dynamic values. This implementation does it by providing user an option to override them inside playbook. 

Upsides:
- it is not breaking change
- playbooks are stable (label changes on portal do not break module)
- API is stable - in case that we feed data to next service
- playbook author can choose meaningful (short) names

Downsides:
- list must be manualy updated 

Other option is to load them from API - but in that case we loose backward compatibility. And any change inside `Choice lists` can brake existing playbook.

<!--- Paste verbatim command output below, e.g. before and after your change -->
Example usage:
```paste below
  vars:
    mapping:
      incident:
        impact:
          1: "high"
          2: "medium"
          3: "low"
        urgency:
          1: "high"
          2: "medium"
          3: "low"
.....

  block:
    - name: Retrieve all incidents
      servicenow.itsm.incident_info:
        mapping: "{{ mapping }}"
      register: result
```
