### PR TITLE
Sys choices

### DIFF
--- a/plugins/module_utils/choices.py
+++ b/plugins/module_utils/choices.py
@@ -9,11 +9,13 @@ __metaclass__ = type
 
 from . import errors
 
+
 class ChoicesClient:
     def __init__(self, table_client, table_name, mapping):
         self.table_client = table_client
         self.table_name = table_name
         self.table_client = table_client
+        self.mapping = mapping
 
     def get_choices(self, table_name, element=None):
         query = {
@@ -38,4 +40,4 @@ class ChoicesClient:
         data = self.get_choices(self.table_name)
         grouped = self.group_choices(data)
         mapped = self.mapping(grouped)
-        return mapping
+        return mapped

--- a/plugins/module_utils/choices.py
+++ b/plugins/module_utils/choices.py
@@ -10,7 +10,9 @@ __metaclass__ = type
 from . import errors
 
 class ChoicesClient:
-    def __init__(self, table_client):
+    def __init__(self, table_client, table_name, mapping):
+        self.table_client = table_client
+        self.table_name = table_name
         self.table_client = table_client
 
     def get_choices(self, table_name, element=None):
@@ -32,7 +34,8 @@ class ChoicesClient:
             result[key] = bucket
         return result
 
-    def get_grouped_choices(self, table_name):
-        data = self.get_choices(table_name)
+    def get_grouped_choices(self):
+        data = self.get_choices(self.table_name)
         grouped = self.group_choices(data)
-        return grouped
+        mapped = self.mapping(grouped)
+        return mapping

--- a/plugins/module_utils/choices.py
+++ b/plugins/module_utils/choices.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2021, XLAB Steampunk <steampunk@xlab.si>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from . import errors
+
+class ChoicesClient:
+    def __init__(self, table_client):
+        self.table_client = table_client
+
+    def get_choices(self, table_name, element=None):
+        query = {
+            "name": table_name,
+        }
+        if element:
+            query["element"] = element
+
+        choices = self.table_client.list_records("sys_choice", query)
+        return choices
+    
+    def group_choices(self, data): 
+        result = dict()
+        for item in data:
+            key = item["element"]
+            bucket = result.get(key, [])
+            bucket.append((item["value"], item["label"]))
+            result[key] = bucket
+        return result
+
+    def get_grouped_choices(self, table_name):
+        data = self.get_choices(table_name)
+        grouped = self.group_choices(data)
+        return grouped

--- a/plugins/module_utils/client.py
+++ b/plugins/module_utils/client.py
@@ -143,6 +143,7 @@ class Client:
         url = "{0}/api/now/{1}".format(self.host, escaped_path)
         if query:
             url = "{0}?{1}".format(url, urlencode(query))
+
         headers = dict(headers or DEFAULT_HEADERS, **self.auth_header)
         if data is not None:
             data = json.dumps(data, separators=(",", ":"))

--- a/plugins/module_utils/incident.py
+++ b/plugins/module_utils/incident.py
@@ -10,18 +10,31 @@ __metaclass__ = type
 from . import choices
 
 
+INCIDENT_QUERY = "incident"
+
+
 empty = ("", "")
 
-
-def get_new_payload_mapping(table_client):
-    choices_client = choices.ChoicesClient(table_client)
-    incident_choices = choices_client.get_grouped_choices("incident")
-
+def incident_mapping(choices):
     correct = dict(
-        impact=incident_choices["severity"],
-        urgency=incident_choices["severity"],
-        state=incident_choices["state"],
-        hold_reason=incident_choices["hold_reason"] + [empty],
-        close_code=incident_choices["close_code"] + [empty]
+        impact=choices["severity"],
+        urgency=choices["severity"],
+        state=choices["state"],
+        hold_reason=choices["hold_reason"] + [empty],
+        close_code=choices["close_code"] + [empty]
     )
     return correct
+
+
+#def get_new_payloadi_mapping(table_client):
+#    choices_client = choices.ChoicesClient(table_client)
+#    incident_choices = choices_client.get_grouped_choices("incident")
+#
+#    correct = dict(
+#        impact=incident_choices["severity"],
+#        urgency=incident_choices["severity"],
+#        state=incident_choices["state"],
+#        hold_reason=incident_choices["hold_reason"] + [empty],
+#        close_code=incident_choices["close_code"] + [empty]
+#    )
+#    return correct

--- a/plugins/module_utils/incident.py
+++ b/plugins/module_utils/incident.py
@@ -7,13 +7,11 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from . import choices
-
-
 INCIDENT_QUERY = "incident"
 
 
 empty = ("", "")
+
 
 def incident_mapping(choices):
     correct = dict(
@@ -24,17 +22,3 @@ def incident_mapping(choices):
         close_code=choices["close_code"] + [empty]
     )
     return correct
-
-
-#def get_new_payloadi_mapping(table_client):
-#    choices_client = choices.ChoicesClient(table_client)
-#    incident_choices = choices_client.get_grouped_choices("incident")
-#
-#    correct = dict(
-#        impact=incident_choices["severity"],
-#        urgency=incident_choices["severity"],
-#        state=incident_choices["state"],
-#        hold_reason=incident_choices["hold_reason"] + [empty],
-#        close_code=incident_choices["close_code"] + [empty]
-#    )
-#    return correct

--- a/plugins/module_utils/incident.py
+++ b/plugins/module_utils/incident.py
@@ -7,23 +7,21 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+from . import choices
 
-PAYLOAD_FIELDS_MAPPING = dict(
-    impact=[("1", "high"), ("2", "medium"), ("3", "low")],
-    urgency=[("1", "high"), ("2", "medium"), ("3", "low")],
-    state=[
-        ("1", "new"),
-        ("2", "in_progress"),
-        ("3", "on_hold"),
-        ("6", "resolved"),
-        ("7", "closed"),
-        ("8", "canceled"),
-    ],
-    hold_reason=[
-        ("", ""),  # Reason not set
-        ("1", "awaiting_caller"),
-        ("3", "awaiting_problem"),
-        ("4", "awaiting_vendor"),
-        ("5", "awaiting_change"),
-    ],
-)
+
+empty = ("", "")
+
+
+def get_new_payload_mapping(table_client):
+    choices_client = choices.ChoicesClient(table_client)
+    incident_choices = choices_client.get_grouped_choices("incident")
+
+    correct = dict(
+        impact=incident_choices["severity"],
+        urgency=incident_choices["severity"],
+        state=incident_choices["state"],
+        hold_reason=incident_choices["hold_reason"] + [empty],
+        close_code=incident_choices["close_code"] + [empty]
+    )
+    return correct

--- a/plugins/modules/incident_info.py
+++ b/plugins/modules/incident_info.py
@@ -251,7 +251,7 @@ def main():
         records = run(module, table_client, choices_client, attachment_client)
         module.exit_json(changed=False, records=records)
     except errors.ServiceNowError as e:
-        raise
+        #raise
         module.fail_json(msg=str(e))
 
 

--- a/tests/integration/targets/attachment/tasks/main.yml
+++ b/tests/integration/targets/attachment/tasks/main.yml
@@ -235,10 +235,10 @@
     - name: Create test incident with attachment - check mode
       servicenow.itsm.incident: &create-incident-attachment
         caller: admin
-        state: new
+        state: "New"
         short_description: Test incident
-        impact: low
-        urgency: low
+        impact: "3 - Low"
+        urgency: "3 - Low"
         attachments:
           - path: targets/attachment/res/sample_file1.txt
       check_mode: true
@@ -247,9 +247,9 @@
     - ansible.builtin.assert: &create-incident-attachment-result
         that:
           - result is changed
-          - result.record.state == "new"
-          - result.record.impact == "low"
-          - result.record.urgency == "low"
+          - result.record.state == "New"
+          - result.record.impact == "3 - Low"
+          - result.record.urgency == "3 - Low"
           - result.record.attachments | length == 1
           - result.record.attachments[0].file_name == "sample_file1.txt"
 

--- a/tests/integration/targets/incident/tasks/main.yml
+++ b/tests/integration/targets/incident/tasks/main.yml
@@ -16,10 +16,10 @@
     - name: Create test incident - check mode
       servicenow.itsm.incident: &create-incident
         caller: admin
-        state: new
+        state: "New"
         short_description: Test incident
-        impact: low
-        urgency: low
+        impact: "3 - Low"
+        urgency: "3 - Low"
         attachments:
           - path: targets/incident/res/sample_file.txt
       check_mode: true
@@ -28,9 +28,9 @@
     - ansible.builtin.assert: &create-incident-result
         that:
           - result is changed
-          - result.record.state == "new"
-          - result.record.impact == "low"
-          - result.record.urgency == "low"
+          - result.record.state == "New"
+          - result.record.impact == "3 - Low"
+          - result.record.urgency == "3 - Low"
           - result.record.attachments | length != 0
           - result.record.attachments[0].file_name == "sample_file.txt"
 
@@ -54,17 +54,17 @@
     - ansible.builtin.assert:
         that:
           - result.records[0].number == test_result.record.number
-          - result.records[0].state == "new"
-          - result.records[0].impact == "low"
-          - result.records[0].urgency == "low"
+          - result.records[0].state == "New"
+          - result.records[0].impact == "3 - Low"
+          - result.records[0].urgency == "3 - Low"
 
 
     - name: Update incident with same urgency and impact - unchanged
       servicenow.itsm.incident:
         caller: admin
         number: "{{ test_result.record.number }}"
-        impact: low
-        urgency: low
+        impact: "3 - Low"
+        urgency: "3 - Low"
       register: result
 
     - ansible.builtin.assert:
@@ -76,18 +76,18 @@
       servicenow.itsm.incident: &update-incident
         caller: admin
         number: "{{ test_result.record.number }}"
-        state: in_progress
-        impact: high
-        urgency: high
+        state: "In Progress"
+        impact: "1 - High"
+        urgency: "1 - High"
       check_mode: true
       register: result
 
     - ansible.builtin.assert: &update-incident-result
         that:
           - result is changed
-          - result.record.state == "in_progress"
-          - result.record.impact == "high"
-          - result.record.urgency == "high"
+          - result.record.state == "In Progress"
+          - result.record.impact == "1 - High"
+          - result.record.urgency == "1 - High"
 
 
     - name: Update incident
@@ -104,9 +104,9 @@
     - ansible.builtin.assert:
         that:
           - result.records[0].number == test_result.record.number
-          - result.records[0].state == "in_progress"
-          - result.records[0].impact == "high"
-          - result.records[0].urgency == "high"
+          - result.records[0].state == "In Progress"
+          - result.records[0].impact == "1 - High"
+          - result.records[0].urgency == "1 - High"
 
 
     - name: Update incident with same params - unchanged
@@ -121,7 +121,7 @@
     - name: Fail closing incident without required data
       servicenow.itsm.incident:
         number: "{{ test_result.record.number }}"
-        state: closed
+        state: Closed
       ignore_errors: true
       register: result
     - ansible.builtin.assert:
@@ -135,7 +135,7 @@
       servicenow.itsm.incident: &update-incident-state
         caller: admin
         number: "{{ test_result.record.number }}"
-        state: resolved
+        state: "Resolved"
         close_code: Solved Remotely (Permanently)
         close_notes: Done testing
       check_mode: true
@@ -144,7 +144,7 @@
     - ansible.builtin.assert: &update-incident-state-result
         that:
           - result is changed
-          - result.record.state == "resolved"
+          - result.record.state == "Resolved"
           - result.record.close_code == "Solved Remotely (Permanently)"
           - result.record.close_notes == "Done testing"
 
@@ -160,7 +160,7 @@
         query:
          - caller: = admin
            number: = {{ test_result.record.number }}
-           state: = resolved
+           state: = Resolved
            close_code: = Solved Remotely (Permanently)
            close_notes: = Done testing
       register: result
@@ -170,7 +170,7 @@
           - result.records | length == 1
           - result.records[0].caller_id != ""
           - result.records[0].number == test_result.record.number
-          - result.records[0].state == "resolved"
+          - result.records[0].state == "Resolved"
           - result.records[0].close_code == "Solved Remotely (Permanently)"
           - result.records[0].close_notes == "Done testing"
 
@@ -183,7 +183,7 @@
     - ansible.builtin.assert:
         that:
           - result.records[0].number == test_result.record.number
-          - result.records[0].state == "resolved"
+          - result.records[0].state == "Resolved"
           - result.records[0].close_code == "Solved Remotely (Permanently)"
           - result.records[0].close_notes == "Done testing"
 
@@ -192,13 +192,13 @@
       servicenow.itsm.incident_info:
         query:
          - close_notes: LIKE Done testing
-           state: = resolved
+           state: = Resolved
       register: result
 
     - ansible.builtin.assert:
         that:
           - result.records[0].close_notes == "Done testing"
-          - result.records[0].state == "resolved"
+          - result.records[0].state == "Resolved"
 
 
     - name: Update incident with same state - unchanged
@@ -214,7 +214,7 @@
       servicenow.itsm.incident: &delete-incident
         caller: admin
         number: "{{ test_result.record.number }}"
-        state: absent
+        state: Absent
       check_mode: true
       register: result
 

--- a/tests/integration/targets/problem/tasks/main.yml
+++ b/tests/integration/targets/problem/tasks/main.yml
@@ -121,13 +121,18 @@
       servicenow.itsm.problem:
         sys_id: "{{ assigned_problem.record.sys_id }}"
         state: root_cause_analysis
-        cause_notes: cause
+        # cause_notes: cause
       register: analyzed_problem
+  
+    - name: fdsfdsgsfdg
+      debug:
+        var: analyzed_problem
+
     - ansible.builtin.assert:
         that:
           - analyzed_problem is changed
           - analyzed_problem.record.state == "root_cause_analysis"
-          - analyzed_problem.record.cause_notes == "cause"
+            #- analyzed_problem.record.cause_notes == "cause"
 
     - name: Start fixing the problem
       servicenow.itsm.problem:

--- a/tests/unit/plugins/conftest.py
+++ b/tests/unit/plugins/conftest.py
@@ -19,6 +19,7 @@ from ansible_collections.servicenow.itsm.plugins.module_utils.table import Table
 from ansible_collections.servicenow.itsm.plugins.module_utils.attachment import (
     AttachmentClient,
 )
+from ansible_collections.servicenow.itsm.plugins.module_utils.choices import ChoicesClient
 
 
 @pytest.fixture
@@ -34,6 +35,11 @@ def table_client(mocker):
 @pytest.fixture
 def attachment_client(mocker):
     return mocker.Mock(spec=AttachmentClient)
+
+
+@pytest.fixture
+def choices_client(mocker):
+    return mocker.Mock(spec=ChoicesClient)
 
 
 @pytest.fixture
@@ -73,7 +79,7 @@ def fail_json_mock(self, **result):
     raise AnsibleRunEnd(False, result)
 
 
-def run_mock(module, client, another_client=None):
+def run_mock(module, client, another_client=None, yet_another_client=None):
     return False, {}, dict(before={}, after={})
 
 

--- a/tests/unit/plugins/modules/test_incident_info.py
+++ b/tests/unit/plugins/modules/test_incident_info.py
@@ -62,7 +62,7 @@ class TestMain:
 
 
 class TestRun:
-    def test_run(self, create_module, table_client, attachment_client):
+    def test_run(self, create_module, table_client, choices_client, attachment_client):
         module = create_module(
             params=dict(
                 instance=dict(host="https://my.host.name", username="user", password="pass"),
@@ -76,6 +76,7 @@ class TestRun:
             dict(q=2, sys_id=4321),
             dict(r=3, sys_id=1212),
         ]
+
         attachment_client.list_records.side_effect = [
             [
                 {
@@ -90,7 +91,9 @@ class TestRun:
             [],
         ]
 
-        records = incident_info.run(module, table_client, attachment_client)
+        choices_client.get_grouped_choices.return_value = {}
+
+        records = incident_info.run(module, table_client, choices_client, attachment_client)
 
         table_client.list_records.assert_called_once_with(
             "incident", dict(number="INC001")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #085".

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Incident

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
User can change almost any enum inside `Choice lists` (https://docs.servicenow.com/bundle/rome-platform-administration/page/administer/field-administration/concept/c_ChoiceLists.html)

<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Table that holds values can be edited on this endpoint. From tests it supports all CRUD opertions.
https://dev????.service-now.com/nav_to.do?uri=%2Fsys_choice_list.do%3Fsysparm_userpref_module%3Ddf35443dc0a8016600170b6df0ac4f5d%26sysparm_clear_stack%3Dtrue

Meaning that module needs to support dynamic values. This implementation does it by requesting values through portal API.

Upsides:
- list is automatically updated - consitent 

Downsides:
- it is breaking change (current playbooks would need to be fixed)
- playbooks are not stable (label changes on portal break module)
- API is not stable - in case that we feed data to next service
- playbook author must remember labels
 
Other option is to allow user edit values in playbook.

